### PR TITLE
Add support for filmographies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,35 @@
 # letterboxd-list-radarr
+
 Connect radarr to letterboxd.com lists
 
 ## Usage
+
 This repository is hosted on heroku. That way you don't have to run the service yourself.
 To use it, you have to:
+
 1. Configure a new list in radarr, using the _Radarr Lists_ provider.
 2. Set _Radarr API URL_ to `https://letterbox-list-radarr.herokuapp.com` (or your custom one, if you choose self-hosting)
 3. Set _Path to list_ to whatever appears in the URL for the list of your choosing after `letterboxd.com`.
 
 Supported Lists:
+
 * Watchilsts: https://letterboxd.com<b>/screeny05/watchlist/</b>
 * Regular Lists: https://letterboxd.com<b>/screeny05/list/jackie-chan-the-definitive-list/</b>
 * Watched Movies: https://letterboxd.com<b>/screeny05/films/</b>
+* Filmography:
+    * Actor: https://letterboxd.com<b>/actor/tom-hanks/</b>
+    * Director: https://letterboxd.com<b>/director/alfred-hitchcock/</b>
+    * Writer: https://letterboxd.com<b>/writer/charlie-kaufman/</b>
+    * Etc.
 
 Others may be supported, but are not tested, yet.
 
 ## Self-hosting
+
 You need a working redis-instance, which is used for caching movie- & list-data.
 
 Following environment-params are supported:
+
 ```
 REDIS_URL
 PORT

--- a/lib/letterboxd/list.ts
+++ b/lib/letterboxd/list.ts
@@ -42,7 +42,7 @@ export const getListPaginated = async (listSlug: string, page: number) => {
     return await getKanpai<LetterboxdListPage>(`${LETTERBOXD_ORIGIN}${listSlug}page/${page}/`, {
         next: ['.paginate-nextprev .next', '[href]', getFirstMatch(LETTERBOX_NEXT_PAGE_REGEX)],
         posters: ['.poster-list .film-poster', {
-            slug: ['$', '[data-film-slug]'],
+            slug: ['$', '[data-target-link]'],
             title: ['.image', '[alt]']
         }]
     });


### PR DESCRIPTION
Hey, thanks for this project. I stumbled on it a few weeks ago and it's working great.

This PR adds support for Letterboxd filmography pages. (Actor, producer, writer, director, etc.). The important differences between filmography and list pages are:

1. For whatever reason, there's no `data-film-slug` attribute in the poster list on these pages. Instead there's `data-target-link`, which seems to hold the same data. `data-target-link` is also present on list pages, so I've switched unconditionally.
2. ~As far as I can tell filmography pages are never paginated (and so `.../page/1` is not valid). Tom Hanks, for example, [has 117 films listed](https://letterboxd.com/actor/tom-hanks/).~ **Edit:** Looks like pagination URLs work after all. I've reverted my change here.

This ended up being a very small change, but let me know if you'd like me to make any tweaks.