### PR TITLE
support user reviews lists

### DIFF
--- a/lib/letterboxd/index.ts
+++ b/lib/letterboxd/index.ts
@@ -26,7 +26,9 @@ export const fetchPostersFromSlug = async (
     }
 
     if (REVIEW_REGEX.test(slug)) {
-        throw new Error("Review lists are not supported.");
+        return await getListCached(slug, undefined, {
+            postersQuery: ".viewing-list .film-poster"
+        });
     }
 
     return await getListCached(slug);

--- a/lib/letterboxd/index.ts
+++ b/lib/letterboxd/index.ts
@@ -6,7 +6,7 @@ import { getCachedFilmsPopular } from "./films-popular";
 const COLLECTION_REGEX = /^\/films\/in\/.*$/;
 const TAGGED_LISTS_REGEX = /^\/.*\/tag\/.*\/lists\/$/;
 const FILMS_POPULAR_REGEX = /^\/films\/popular\/.*?$/;
-const REVIEW_REGEX = /^\/reviews\/.*$/;
+const REVIEW_REGEX = /^\/.*\/reviews\/.*$/;
 
 export const fetchPostersFromSlug = async (
     slug: string
@@ -26,7 +26,7 @@ export const fetchPostersFromSlug = async (
     }
 
     if (REVIEW_REGEX.test(slug)) {
-        return await getListCached(slug, undefined, {
+        return await getListCached(slug, {
             postersQuery: ".viewing-list .film-poster"
         });
     }

--- a/lib/letterboxd/list.ts
+++ b/lib/letterboxd/list.ts
@@ -25,16 +25,12 @@ interface GetListOptions {
 
 export const getList = async (
     listSlug: string,
-    onPage?: (page: number) => void,
     options?: GetListOptions
 ): Promise<LetterboxdPoster[]> => {
     const posters: LetterboxdPoster[] = [];
     let nextPage: number | null = 1;
     while (nextPage) {
         const result = await getListPaginated(listSlug, nextPage, options);
-        if (onPage) {
-            onPage(nextPage);
-        }
         posters.push(...result.posters);
         nextPage = Number.parseInt(result.next);
         nextPage = Number.isNaN(nextPage) ? null : nextPage;
@@ -44,7 +40,6 @@ export const getList = async (
 
 export const getListCached = async (
     listSlug: string,
-    onPage?: (page: number) => void,
     options?: GetListOptions
 ): Promise<LetterboxdPoster[]> => {
     const cached = await cache.get(listSlug);
@@ -55,7 +50,7 @@ export const getListCached = async (
         await cache.del(listSlug);
     }
 
-    const posters = await getList(listSlug, onPage, options);
+    const posters = await getList(listSlug, options);
     await cache.set(listSlug, posters, LIST_CACHE_TIMEOUT);
     return posters;
 };
@@ -68,7 +63,6 @@ export const getListPaginated = async (
     const {
         postersQuery = ".poster-list .film-poster"
     } = options || {};
-
     return await getKanpai<LetterboxdListPage>(
         `${LETTERBOXD_ORIGIN}${listSlug}page/${page}/`,
         {


### PR DESCRIPTION
This patches up the paths to support scraping movies from user's reviews lists.

it:

- modifies `getList` methods:
  1) removes unused `onPage: (page) => void` argument in those methods
  2) adds an `options?: { postersQuery?: string }` argument to allow configuring the query used to match poster elements
 
 - patches the `REVIEWS_REGEX` to detect a user's film review page slug, e.g. `<user>/films/reviews/...`
 
 
 With these changes I can successfully scrape a users reviews page 👍 