### PR TITLE
Fix: lists scraping - update css query for posters

### DIFF
--- a/lib/letterboxd/list.ts
+++ b/lib/letterboxd/list.ts
@@ -67,7 +67,7 @@ export const getListPaginated = async (
                 getFirstMatch(LETTERBOXD_NEXT_PAGE_REGEX),
             ],
             posters: [
-                "[data-component-class=\"globals.comps.LazyPoster\"]",
+                "[data-component-class=\"LazyPoster\"]",
                 {
                     slug: ["$", "[data-target-link]"],
                     title: ["$", "[data-item-name]"],


### PR DESCRIPTION
Updates the css selector match for scraping poster items

Fixes #57 