### PR TITLE
add optional FlareSolverr proxy support for bypassing Cloudflare

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Following environment-params are supported:
 -   `PORT` - The http-port which the application listens on
 -   `LOG_LEVEL` - Set to `debug` for more info. Defaults to `info`
 -   `USER_AGENT` - Allows you to set your own user-agent string
+-   `FLARESOLVERR_URL` - (Optional) URL to [FlareSolverr](https://github.com/FlareSolverr/FlareSolverr) instance (e.g., `http://flaresolverr:8191/v1`). When set, routes requests through FlareSolverr to bypass Cloudflare protection
 
 1. Clone this repo
 2. Make sure you have configured the env-variables

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,11 +11,24 @@ services:
         environment:
             - REDIS_URL=redis://redis:6379
             - PORT=4200
+            # Uncomment to enable FlareSolverr proxy for bypassing Cloudflare
+            # - FLARESOLVERR_URL=http://flaresolverr:8191/v1
         user: node
         command: npm run watch
+        depends_on:
+            - redis
     redis:
         image: redis:6.0
         command: redis-server /usr/local/etc/redis/redis.conf --appendonly yes
         volumes:
             - ./redis-data/:/data
             - ./redis.conf:/usr/local/etc/redis/redis.conf
+    flaresolverr:
+        image: ghcr.io/flaresolverr/flaresolverr:latest
+        ports:
+            - 8191:8191
+        environment:
+            - LOG_LEVEL=info
+            - LOG_HTML=false
+            - CAPTCHA_SOLVER=none
+            - TZ=UTC

--- a/lib/axios/index.ts
+++ b/lib/axios/index.ts
@@ -13,7 +13,36 @@ const instance = Axios.create({
 
 const robotsGuard = new RobotsGuard(instance);
 
+const FLARESOLVERR_URL = process.env.FLARESOLVERR_URL;
+
 export default async function get(url: string): Promise<string> {
+    // If FlareSolverr is configured, use it and skip robots.txt
+    if (FLARESOLVERR_URL) {
+        axiosLogger.debug(`Using FlareSolverr proxy for ${url}`);
+        const response = await instance.post(FLARESOLVERR_URL, {
+            cmd: "request.get",
+            url: url,
+            maxTimeout: 60000,
+        });
+
+        if (response.data?.status === "error") {
+            axiosLogger.error(
+                `FlareSolverr error for ${url}: ${response.data.message}`
+            );
+            throw new Error(`FlareSolverr error: ${response.data.message}`);
+        }
+
+        if (!response.data?.solution?.response) {
+            axiosLogger.error(
+                `FlareSolverr returned invalid response for ${url}`
+            );
+            throw new Error("FlareSolverr returned invalid response");
+        }
+
+        return response.data.solution.response;
+    }
+
+    // Standard path with robots.txt checking
     if (!robotsGuard.isLoaded) {
         await robotsGuard.load();
     }

--- a/lib/axios/index.ts
+++ b/lib/axios/index.ts
@@ -15,15 +15,77 @@ const robotsGuard = new RobotsGuard(instance);
 
 const FLARESOLVERR_URL = process.env.FLARESOLVERR_URL;
 
+// FlareSolverr session management for cookie reuse
+let flaresolverrSession: string | null = null;
+let sessionCreationPromise: Promise<string> | null = null;
+
+async function getOrCreateSession(): Promise<string> {
+    if (flaresolverrSession) {
+        return flaresolverrSession;
+    }
+
+    // Prevent multiple concurrent session creations
+    if (sessionCreationPromise) {
+        return sessionCreationPromise;
+    }
+
+    sessionCreationPromise = (async () => {
+        axiosLogger.debug("Creating new FlareSolverr session");
+        const response = await instance.post(FLARESOLVERR_URL!, {
+            cmd: "sessions.create",
+        });
+
+        if (response.data?.status === "error") {
+            throw new Error(`Failed to create FlareSolverr session: ${response.data.message}`);
+        }
+
+        flaresolverrSession = response.data.session;
+        axiosLogger.debug(`Created FlareSolverr session: ${flaresolverrSession}`);
+        return flaresolverrSession!;
+    })();
+
+    try {
+        return await sessionCreationPromise;
+    } finally {
+        sessionCreationPromise = null;
+    }
+}
+
 export default async function get(url: string): Promise<string> {
     // If FlareSolverr is configured, use it and skip robots.txt
     if (FLARESOLVERR_URL) {
-        axiosLogger.debug(`Using FlareSolverr proxy for ${url}`);
+        const session = await getOrCreateSession();
+        axiosLogger.debug(`Using FlareSolverr session ${session} for ${url}`);
+
         const response = await instance.post(FLARESOLVERR_URL, {
             cmd: "request.get",
             url: url,
+            session: session,
             maxTimeout: 60000,
         });
+
+        // If session expired or invalid, recreate it and retry
+        if (response.data?.status === "error" && response.data.message?.includes("session")) {
+            axiosLogger.debug("Session expired, recreating...");
+            flaresolverrSession = null;
+            const newSession = await getOrCreateSession();
+
+            const retryResponse = await instance.post(FLARESOLVERR_URL, {
+                cmd: "request.get",
+                url: url,
+                session: newSession,
+                maxTimeout: 60000,
+            });
+
+            if (retryResponse.data?.status === "error") {
+                axiosLogger.error(
+                    `FlareSolverr error for ${url}: ${retryResponse.data.message}`
+                );
+                throw new Error(`FlareSolverr error: ${retryResponse.data.message}`);
+            }
+
+            return retryResponse.data.solution.response;
+        }
 
         if (response.data?.status === "error") {
             axiosLogger.error(

--- a/lib/express/send-chunked-json.ts
+++ b/lib/express/send-chunked-json.ts
@@ -3,8 +3,9 @@ import { Response } from "express";
 // Send keep-alive every 5 seconds.
 const KEEP_ALIVE_INTERVAL = 5 * 1000;
 
-// If no push happened after 30 seconds, close connection.
-const PUSH_TIMEOUT = 30 * 1000;
+// If no push happened after timeout, close connection.
+// FlareSolverr can take 30-60 seconds per request, so use longer timeout when configured.
+const PUSH_TIMEOUT = process.env.FLARESOLVERR_URL ? 120 * 1000 : 30 * 1000;
 
 /**
  * Stream array of objects as JSON to client.


### PR DESCRIPTION
When FLARESOLVERR_URL env var is set, routes all requests through FlareSolverr instead of making direct HTTP requests. This helps when Letterboxd is behind Cloudflare protection.

- Add FlareSolverr proxy logic in lib/axios/index.ts
- Skip robots.txt checks when using FlareSolverr
- Increase response timeout to 120s when FlareSolverr is enabled
- Add FlareSolverr service to docker-compose.yml
- Document FLARESOLVERR_URL in README